### PR TITLE
Add configuration of auth.madlambda.io

### DIFF
--- a/auth/Dockerfile
+++ b/auth/Dockerfile
@@ -1,0 +1,18 @@
+# Signer set up based on documentation at:
+# http://doc.cat-v.org/inferno/4th_edition/release_notes/install
+
+FROM madlambda/inferno-linux-x86:0.1
+
+ADD ./start-emu.sh /start-emu.sh
+ADD ./lib/ndb/local /work/lib/ndb/local
+ADD ./usr/inferno/setup-auth.sh /work/usr/inferno/setup-auth.sh
+
+# Default screen resolution
+ENV WINRES 	1024x768
+ENV TZ		Brazil_East
+ENV DOMAIN	madlambda.io
+
+RUN useradd -m inferno
+ENTRYPOINT ["/start-emu.sh"]
+
+

--- a/auth/README.md
+++ b/auth/README.md
@@ -1,0 +1,64 @@
+# Authentication service
+
+Before any inferno machine can access resources on inferno servers it needs
+to obtain a valid certificate from a signer (or auth service).
+
+Madlambda.io has a signer running at auth.madlambda.io and here is the 
+script to build and configure this signer.
+
+## Building
+
+To build the docker image just type:
+
+```
+% mk image
+```
+
+## Starting
+
+The first time you run the auth service you'll need to answer some 
+security questions (like the passphrase of the keyfs).
+
+Execute:
+
+```
+% docker run -it madlambda/inferno-auth:0.1
+Configuring signer.
+!!! You are about to reset the auth keys file.
+Press ENTER to continue or CTRL-C to abort
+
+
+Generating certificates for  madlambda.io ...
+Key: 
+Confirm key: 
+services running:
+       1        1       root    0:00.0    release   148K Sh[$Sys]
+      16       15       root    0:00.0        alt    17K Cs
+      20       19       root    0:00.0       recv    25K Keyfs
+      21       19       root    0:00.0    release    46K Styx[$Sys]
+      22       19       root    0:00.0       recv    25K Keyfs
+      24        1       root    0:00.0        alt     9K Listen
+      26        1       root    0:00.0    release     9K Listen[$Sys]
+      28        1       root    0:00.0        alt     9K Listen
+      30        1       root    0:00.0    release     9K Listen[$Sys]
+      32        1       root    0:00.0        alt     9K Listen
+      34        1       root    0:00.0    release     9K Listen[$Sys]
+      36        1       root    0:00.0        alt     9K Listen
+      38        1       root    0:00.0    release     9K Listen[$Sys]
+      40        1       root    0:00.0      ready    74K Ps[$Sys]
+Press any key to stop the auth service
+```
+It shows the processes running, just make sure Keyfs is running.
+
+## Customizations
+
+The image has the following environment variables:
+
+- DOMAIN: Set to the domain of your site/cluster
+- TZ: Timezone of the server
+- WINRES: Graphical window resolution
+
+If you change the DOMAIN, then make sure to update the field 
+dnsdomain of the file /lib/ndb/local also.
+
+That's all folks!

--- a/auth/lib/ndb/local
+++ b/auth/lib/ndb/local
@@ -1,0 +1,20 @@
+database=
+	file=/lib/ndb/local
+	file=/lib/ndb/dns
+	file=/lib/ndb/inferno
+	file=/lib/ndb/common
+
+#
+# default site-wide resources
+#
+infernosite=
+	dnsdomain=madlambda.io
+	dns=dns1.registrar-servers.com	# namecheap resolver
+	SIGNER=auth.madlambda.io
+	FILESERVER=file.madlambda.io
+	smtp=your_smtpserver_here
+	pop3=your_pop3server_here
+	PROXY=your_httpproxy_here
+	GAMES=your_games_server
+	registry=your_registry_server
+	gridsched=your_inferno_grid_scheduler

--- a/auth/mkfile
+++ b/auth/mkfile
@@ -1,0 +1,9 @@
+# Builds the authentication service container
+
+IMAGE=madlambda/inferno-auth:0.1
+
+all:QV:
+	echo 'run: mk image'
+
+image:QV:
+	docker build -t $IMAGE .

--- a/auth/start-emu.sh
+++ b/auth/start-emu.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+trap "echo TRAPed signal" HUP INT QUIT TERM
+
+# start service in background here
+/work/Linux/386/bin/emu -g $WINRES /usr/inferno/setup-auth.sh $DOMAIN $WINRES $TZ
+
+echo "Closing container..."
+

--- a/auth/usr/inferno/setup-auth.sh
+++ b/auth/usr/inferno/setup-auth.sh
@@ -1,0 +1,32 @@
+#!/dis/sh.dis
+
+domain=$1
+winres=$2
+tz=$3
+
+echo 'Configuring signer.'
+
+bind /locale/$tz /locale/timezone
+
+echo '!!! You are about to reset the auth keys file.'
+echo 'Press ENTER to continue or CTRL-C to abort'
+read
+
+cp /dev/null /keydb/keys
+chmod 600 /keydb/keys
+echo 'Generating certificates for ' $domain '...'
+auth/createsignerkey $domain
+
+svc/auth
+
+echo 'services running:'
+
+ps
+
+# Sleep
+echo 'Press any key to get shell'
+read
+
+sh
+
+echo 'exiting'


### PR DESCRIPTION
Yes, we have inferno machines =)

```
[07:45] [server1.madlambda.io ~] # docker run -it --net=host madlambda/inferno-auth:0.1
Configuring signer.
!!! You are about to reset the auth keys file.
Press ENTER to continue or CTRL-C to abort


Generating certificates for  madlambda.io ...
Key:
Confirm key:
services running:
       1        1       root    0:00.0    release   148K Sh[$Sys]
      16       15       root    0:00.0        alt    17K Cs
      20       19       root    0:00.0       recv    25K Keyfs
      21       19       root    0:00.0    release    46K Styx[$Sys]
      22       19       root    0:00.0       recv    25K Keyfs
      24        1       root    0:00.0        alt     9K Listen
      26        1       root    0:00.0    release     9K Listen[$Sys]
      28        1       root    0:00.0        alt     9K Listen
      30        1       root    0:00.0    release     9K Listen[$Sys]
      32        1       root    0:00.0        alt     9K Listen
      34        1       root    0:00.0    release     9K Listen[$Sys]
      36        1       root    0:00.0        alt     9K Listen
      38        1       root    0:00.0    release     9K Listen[$Sys]
      40        1       root    0:00.0      ready    74K Ps[$Sys]
Press any key to get shell
```