### PR TITLE
Add basic deploy convention supporting multiple users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,18 @@
 # madlambda.io
-madlambda.io
+
+madlambda.io rules:
+
+- Every global change in the servers must be automated in this repository.
+- Just the madlambda owners have root access to the servers.
+- Users should use their own home directory to store personal stuff.
+
+# installation
+
+Clone this repo inside /root and run:
+
+```
+# ./install.sh
+# systemctl start unit
+# ./unit/apply.sh
+```
+

--- a/etc/unit.default
+++ b/etc/unit.default
@@ -1,4 +1,3 @@
 UNITDIR=/usr/local/unit
 DAEMON_ARGS="--log /var/log/unit.log --pid /var/run/unit.pid"
 
-

--- a/etc/unit.default
+++ b/etc/unit.default
@@ -1,3 +1,3 @@
 UNITDIR=/usr/local/unit
-DAEMON_ARGS="--log /var/log/unit.log --pid /var/run/unit.pid"
+UNIT_ARGS="--log /var/log/unit.log --pid /var/run/unit.pid"
 

--- a/etc/unit.default
+++ b/etc/unit.default
@@ -1,0 +1,4 @@
+UNITDIR=/usr/local/unit
+DAEMON_ARGS="--log /var/log/unit.log --pid /var/run/unit.pid"
+
+

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+UNITDIR=/usr/local/unit
+export PATH=$UNITDIR/sbin:$PATH
+
+if [ ! -x "$UNITDIR/sbin/unitd" ]; then
+	echo "Unit is not installed at $UNITDIR"
+	exit 1
+fi
+
+if ! mkdir -p /etc/default; then
+	echo "failed to create /etc/default"
+	exit 1
+fi
+
+if ! cp etc/unit.default /etc/default/unit; then
+	echo "failed to copy unit defaults"
+	exit 1
+fi
+
+if ! cp systemd/unit.service /etc/systemd/system/unit.service; then
+	echo "failed to copy unit.service to /etc/systemd/system"
+	exit 1
+fi
+
+chmod 664 /etc/systemd/system/unit.service
+
+if ! systemctl enable unit.service; then
+	echo "failed to enable systemd service"
+	exit 1
+fi
+
+systemctl daemon-reload
+
+if ! mkdir -p /var/www; then
+	echo "failed to create /var/www"
+	exit 1
+fi
+
+if ! cp -r www/* /var/www; then
+	echo "failed to copy www files"
+	exit 1
+fi
+
+if ! chown -R nobody:nogroup /var/www; then 
+	echo "failed to change user and group of /var/www"
+	exit 1
+fi
+
+echo "services installed"
+exit 0
+
+

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
-UNITDIR=/usr/local/unit
+. ./etc/unit.default
+
 export PATH=$UNITDIR/sbin:$PATH
 
 if [ ! -x "$UNITDIR/sbin/unitd" ]; then

--- a/systemd/unit.service
+++ b/systemd/unit.service
@@ -7,7 +7,7 @@ After=network-online.target
 Type=forking
 PIDFile=/var/run/unit.pid
 EnvironmentFile=-/etc/default/unit
-ExecStart=/usr/local/unit/sbin/unitd $DAEMON_ARGS
+ExecStart=/usr/local/unit/sbin/unitd $UNIT_ARGS
 ExecReload=
 
 [Install]

--- a/systemd/unit.service
+++ b/systemd/unit.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=NGINX Unit
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=forking
+PIDFile=/var/run/unit.pid
+EnvironmentFile=-/etc/default/unit
+ExecStart=/usr/local/unit/sbin/unitd $DAEMON_ARGS
+ExecReload=
+
+[Install]
+WantedBy=multi-user.target

--- a/unit/apply.sh
+++ b/unit/apply.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+
+if ! which jq >/dev/null; then
+	echo "jq is required. Aborting..."
+	exit 1
+fi
+
+. /etc/default/unit
+
+UNITPID=/var/run/unit.pid
+UNITSOCK=$UNITDIR/control.unit.sock
+
+if [ ! -f $UNITPID ]; then
+	echo "Unit is not running (File not found $UNITPID)"
+	exit 1
+fi
+
+if [ ! -S $UNITSOCK ]; then
+	echo "Socket file is not at $UNITSOCK"
+	exit 1
+fi
+
+CURL="curl --silent --unix-socket $UNITSOCK"
+
+# test control socket connectivity
+if ! $CURL 127.0/ | jq -e ".config" >/dev/null; then
+	echo "failed to get Unit config"
+	exit 1
+fi
+
+# apply basic config structure
+if ! $CURL -XPUT 127.0/config --data-binary @./unit/config.json | \
+	jq -e ".success" >/dev/null; then
+
+	echo "failed to set basic config"
+	exit 1
+fi
+
+cd unit/apps
+
+for name in $(ls); do
+        echo "Applying app config: $name"
+
+        if ! $CURL -XPUT "127.0/config/applications/$name" --data-binary \
+                "@./$name/config.json" | jq -e ".success" >/dev/null; then
+
+                echo "failed to apply application $name"
+                exit 1
+        fi
+done
+
+cd ../routes.d
+
+for file in $(ls *.json); do
+	if ! $CURL -XPOST 127.0/config/routes --data-binary "@$file" | \
+		jq -e ".success" >/dev/null; then
+
+		echo "failed to apply route: unit/routes.d/$file"
+		exit 1
+	fi
+done
+
+$CURL 127.0/
+echo "Unit configured"

--- a/unit/apps/container-example/config.json
+++ b/unit/apps/container-example/config.json
@@ -1,0 +1,24 @@
+{
+        "type": "external",
+        "working_directory": "/home/i4k/src/unit-container-tests",
+        "executable": "/home/i4k/src/unit-container-tests/container-example",
+	"user": "root",
+	"group": "root",
+        "isolation": {
+                "namespaces": {
+                        "credential": true,
+                        "mount": true,
+                        "uname": true,
+                        "network": true,
+                        "cgroup": true,
+                        "pid": true
+                },
+                "uidmap": [
+                        {"container": 0, "host": 65534, "size": 1}
+                ],
+                "gidmap": [
+                        {"container": 0, "host": 65534, "size": 1}
+                ]
+        }
+}
+

--- a/unit/config.json
+++ b/unit/config.json
@@ -1,0 +1,28 @@
+{
+	"listeners": {
+		"*:80": {
+			"pass": "routes"
+		}
+	},
+	"routes": [],
+	"applications": {},
+	"settings": {
+		"http": {
+			"header_read_timeout": 10,
+			"body_read_timeout": 10,
+			"send_timeout": 10,
+			"idle_timeout": 10,
+			"max_body_size": 3146000,
+			"static": {
+				"mime_types": {
+					"text/plain": [
+						".txt",
+						"README",
+						"CHANGES"
+					]
+				}
+			}
+		}
+	}
+}
+

--- a/unit/routes.d/container.json
+++ b/unit/routes.d/container.json
@@ -1,0 +1,9 @@
+{
+	"match": {
+		"host": "i4k.madlambda.io",
+		"uri": "/container"
+	},
+	"action": {
+		"pass": "applications/container-example"
+	}
+}

--- a/unit/routes.d/i4k.json
+++ b/unit/routes.d/i4k.json
@@ -1,0 +1,8 @@
+{
+	"match": {
+		"host": "i4k.madlambda.io"
+	},
+	"action": {
+		"share": "/home/i4k/www"
+	}
+}

--- a/unit/routes.d/www.json
+++ b/unit/routes.d/www.json
@@ -1,0 +1,8 @@
+{
+	"match": {
+		"host": "www.madlambda.io"
+	},
+	"action": {
+		"share": "/var/www"
+	}
+}

--- a/www/index.html
+++ b/www/index.html
@@ -1,0 +1,9 @@
+<html>
+	<head>
+		<title>Madlab Team</title>
+	</head>
+	<body>
+		Hello World
+	</body>
+</html>
+


### PR DESCRIPTION
The idea is having a server with conventions for each madlab member to add content and/or applications.

What we have now:

- http://www.madlambda.io/
- http://i4k.madlambda.io/
- http://i4k.madlambda.io/container

If anyone of the group wants to add a personal blog or any stuff, just make a PR in this repo.

The server runs an NGINX Unit on port 80. The folder unit contains a directory structure for routes and apps.
The future goal is to make the madlambda.io server be completely managed by this repository, for example, maybe by making a webhook ping a URL like `madlambda.io/check-updates` that compares the master revision with current and apply the scripts if they don't match.

The script `install.sh` in the root just installs systemd service and other stuffs.
The script unit/apply.sh installs all applications defined in unit/apps then configures all routes in unit/routes.d.

The content-specific of each user should be stored in personal (maybe private) repositories and just the app configs and routes are defined here.

`TODO: script to install unit (either by apt or from source).`