### PR TITLE
Add wildcard SSL

### DIFF
--- a/apps/redirect-to-https/wsgi.py
+++ b/apps/redirect-to-https/wsgi.py
@@ -10,11 +10,12 @@ def application(environ, start_response):
 
 	url += quote(environ.get('SCRIPT_NAME', ''))
 	url += quote(environ.get('PATH_INFO', ''))
+
 	if environ.get('QUERY_STRING'):
 		url += '?' + environ['QUERY_STRING']
 
 	status = "301 Moved Permanently"
-	headers = [('Location',url),('Content-Length','0')]
+	headers = [('Location', url), ('Content-Length', '0')]
 
 	start_response(status, headers)
 	return []

--- a/apps/redirect-to-https/wsgi.py
+++ b/apps/redirect-to-https/wsgi.py
@@ -1,0 +1,20 @@
+from urllib import quote
+
+def application(environ, start_response):
+	url = 'https://'
+
+	if environ.get('HTTP_HOST'):
+		url += environ['HTTP_HOST']
+	else:
+		url += environ['SERVER_NAME']
+
+	url += quote(environ.get('SCRIPT_NAME', ''))
+	url += quote(environ.get('PATH_INFO', ''))
+	if environ.get('QUERY_STRING'):
+		url += '?' + environ['QUERY_STRING']
+
+	status = "301 Moved Permanently"
+	headers = [('Location',url),('Content-Length','0')]
+
+	start_response(status, headers)
+	return []

--- a/generate-ssl-chain.sh
+++ b/generate-ssl-chain.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+
+# Generate the wildcard SSL certificate using the DNS method.
+
+if [ "$#" -lt 1 ]; then
+	echo "Usage: $0 <email>"
+	exit 0
+fi
+
+DOMAIN="*.madlambda.io"
+EMAIL="$1"
+ACMESERVER="https://acme-v02.api.letsencrypt.org/directory"
+
+if ! certbot certonly \
+	--manual --preferred-challenges=dns --email $EMAIL \
+	--server $ACMESERVER --agree-tos \
+	-d $DOMAIN; then
+
+	echo "failed to generate certificate chain"
+	exit 1
+fi
+
+OUTDIR=/etc/letsencrypt/live/madlambda.io
+cat $OUTDIR/privkey.pem $OUTDIR/fullchain.pem > $OUTDIR/unit-chain.pem
+
+echo "Unit chain generated at: $OUTDIR/unit-chain.pem"
+exit 0
+
+
+

--- a/generate-ssl-chain.sh
+++ b/generate-ssl-chain.sh
@@ -25,6 +25,3 @@ cat $OUTDIR/privkey.pem $OUTDIR/fullchain.pem > $OUTDIR/unit-chain.pem
 
 echo "Unit chain generated at: $OUTDIR/unit-chain.pem"
 exit 0
-
-
-

--- a/unit/config.json
+++ b/unit/config.json
@@ -1,17 +1,28 @@
 {
 	"listeners": {
 		"*:80": {
+			"pass": "applications/redirect-to-https"
+		},
+		"*:443": {
 			"pass": "routes"
 		}
 	},
 	"routes": [],
-	"applications": {},
+	"applications": {
+		"redirect-to-https": {
+			"type": "python",
+			"user": "root",
+			"group": "root",
+			"module": "wsgi",
+			"path": "/root/madlambda.io/apps/redirect-to-https"
+		}
+	},
 	"settings": {
 		"http": {
 			"header_read_timeout": 10,
 			"body_read_timeout": 10,
 			"send_timeout": 10,
-			"idle_timeout": 10,
+			"idle_timeout": 120,
 			"max_body_size": 3146000,
 			"static": {
 				"mime_types": {


### PR DESCRIPTION
Add https support using wildcard certs from `Let's Encrypt` project.

- https://www.madlambda.io/
- https://i4k.madlambda.io/

https://www.ssllabs.com/ssltest/analyze.html?d=www.madlambda.io&latest

Also, add a simple script to generate the wildcard certs using the DNS method.